### PR TITLE
fix: check if there are commits besides just commits being defined

### DIFF
--- a/custom/semantic-release-defer-release.js
+++ b/custom/semantic-release-defer-release.js
@@ -1,7 +1,7 @@
 const analyzeCommits = (config, context) => {
     const { logger, commits } = context
 
-    if (commits) {
+    if (commits && commits.length > 0) {
         const { message, commit } = commits[0]
         const defer = /\[(defer|skip)[ -]release\]/gi
 


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/LIBS-316

Looking at [this failure](https://github.com/dhis2/ui/actions/runs/2226744578) you can see that the publish step is failing, even though it should have been skipped because of the `[skip release]` in the commit message. In the [workflow definition](https://github.com/dhis2/ui/blob/master/.github/workflows/dhis2-verify-lib.yml#L151) we can see that this publish step uses our own semantic release action (this repo).

The failure we're seeing is `The automated release failed with TypeError: Cannot destructure property 'message' of 'commits[0]' as it is undefined.`. The first part comes from this line:

https://github.com/dhis2/action-semantic-release/blob/f55d75afec0ab207bfb6eb1daea527714c106889/index.js#L112

The second part is from: 

https://github.com/dhis2/action-semantic-release/blob/9e3b95192e27bfb9d9885270f754ddff195d6b16/custom/semantic-release-defer-release.js#L5

It seems Viktor already tried to address this in https://github.com/dhis2/action-semantic-release/commit/9e3b95192e27bfb9d9885270f754ddff195d6b16, but this check is not enough. `commits` is defined, but it's empty since semantic release is filtering out the skip release commits. I've added a check that should catch this.

I'm not using `commits?.length > 0` since we're not using babel and thus eslint was complaining about unrecognized syntax.