### PR TITLE
fix: ignore libs for apphub publish

### DIFF
--- a/custom/semantic-release-apphub.js
+++ b/custom/semantic-release-apphub.js
@@ -43,11 +43,8 @@ exports.verifyConditions = (config, context) => {
     const d2Config = require(configPath)
 
     if (d2Config.type === 'lib') {
-        throw new SemanticReleaseError(
-            'App Hub does not support publishing libraries.',
-            'EAPPHUBSUPPORT',
-            "The type in d2.config.js must not be 'lib'"
-        )
+        logger.log('App Hub publish will be skipped for library', pkgRoot)
+        return
     }
 
     if (!d2Config.id) {
@@ -93,6 +90,11 @@ exports.publish = async (config, context) => {
 
     const configPath = path.join(basePath, 'd2.config.js')
     const d2Config = require(configPath)
+
+    if (d2Config.type === 'lib') {
+        logger.log('App Hub publish skipped for library', pkgRoot)
+        return
+    }
 
     if (semver.lt(pkg.version, nextRelease.version)) {
         throw new SemanticReleaseError(


### PR DESCRIPTION
Skip libraries when publishing to app hub (instead of throwing and causing the entire script to fail). This way we can have a library in in a repo where an app is published to the app hub.

The action from this branch is already live in the Capture App (https://github.com/dhis2/capture-app/actions/runs/4262678639/jobs/7418844330). We do not publish the lib anywhere yet.