### PR TITLE
fix: skip publish step too if missing d2 config

### DIFF
--- a/custom/semantic-release-apphub.js
+++ b/custom/semantic-release-apphub.js
@@ -92,6 +92,18 @@ exports.publish = async (config, context) => {
     const pkg = fs.readJsonSync(packagePath)
 
     const configPath = path.join(basePath, 'd2.config.js')
+    if (!fs.existsSync(configPath)) {
+        logger.warn(
+            `Failed to locate d2.config.js file, does it exist in ${path.resolve(
+                pkgRoot
+            )}?`
+        )
+        logger.warn(
+            'd2.config.js is necessary to automatically publish to the App Hub. Skipping',
+            pkgRoot
+        )
+        return
+    }
     const d2Config = require(configPath)
 
     if (d2Config.type === 'lib') {

--- a/dist/index.js
+++ b/dist/index.js
@@ -35941,6 +35941,18 @@ exports.publish = async (config, context) => {
     const pkg = fs.readJsonSync(packagePath)
 
     const configPath = path.join(basePath, 'd2.config.js')
+    if (!fs.existsSync(configPath)) {
+        logger.warn(
+            `Failed to locate d2.config.js file, does it exist in ${path.resolve(
+                pkgRoot
+            )}?`
+        )
+        logger.warn(
+            'd2.config.js is necessary to automatically publish to the App Hub. Skipping',
+            pkgRoot
+        )
+        return
+    }
     const d2Config = require(configPath)
 
     if (d2Config.type === 'lib') {


### PR DESCRIPTION
I assumed falsely that returning early in the `verifyConditions` step of the plugins would skip the other steps of the plugin, but it does not -- then, in the `publish` step of the appHub plugin, `d2.config.js` is `require`d, which throws an error if a package doesn't have it: [failed workflow run](https://github.com/dhis2-chap/chap-frontend-monorepo/actions/runs/13370019126/job/37336335589)